### PR TITLE
Ensure child and property exists.

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -62,7 +62,9 @@ function clone(parent, circular) {
        circular references for it */
     for(i in circularReplace) {
       var c = circularReplace[i];
-      c.child[c.i] = circularResolved[c.resolveTo];
+      if (c && c.child && c.i in c.child) {
+        c.child[c.i] = circularResolved[c.resolveTo];
+      }
     }
     return cloned;
   }


### PR DESCRIPTION
Hello, I was having this issue:

```
      c.child[c.i] = circularResolved[c.resolveTo];
                   ^
TypeError: Cannot set property 'undefined' of undefined
```

I changed it so that it checks for them before trying to access them. It solves my issue but I'm not sure that's the real issue.
