### PR TITLE
Fix for obscure bug when running in VM

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -40,14 +40,14 @@ function clone(parent, circular) {
         // Add to list of all parent objects
         circularParent[context] = parent;
         // Now continue cloning...
-        if (parent instanceof Array) {
+        if (parent.constructor.name === 'Array') {
           child = [];
           for(i in parent)
             child[i] = _clone(parent[i], context + '[' + i + ']', child, i);
         }
-        else if (parent instanceof Date)
+        else if (parent.constructor.name === 'Date')
           child = new Date(parent.getTime());
-        else if (parent instanceof RegExp)
+        else if (parent.constructor.name === 'RegExp')
           child = new RegExp(parent.source);
         else {
           child = {};
@@ -84,14 +84,14 @@ function clone(parent, circular) {
     if (typeof parent == 'object') {
       if (parent == null)
         return parent;
-      if (parent instanceof Array) {
+      if (parent.constructor.name === 'Array') {
         child = [];
         for(i in parent)
           child[i] = clone(parent[i], circular);
       }
-      else if (parent instanceof Date)
+      else if (parent.constructor.name === 'Date')
         child = new Date(parent.getTime() );
-      else if (parent instanceof RegExp)
+      else if (parent.constructor.name === 'RegExp')
         child = new RegExp(parent.source);
       else {
         child = {};

--- a/test.js
+++ b/test.js
@@ -158,3 +158,14 @@ exports['clonePrototype'] = function(test) {
 
   test.done();
 }
+
+exports['cloneWithinNewVMContext'] = function(test) {
+  var vm = require('vm');
+  var ctx = vm.createContext({ clone: clone });
+  var script = "clone( {array: [1, 2, 3], date: new Date(), regex: /^foo$/ig} );";
+  var results = vm.runInContext(script, ctx);
+  test.ok(results.array instanceof Array);
+  test.ok(results.date instanceof Date);
+  test.ok(results.regex instanceof RegExp);
+  test.done();
+}


### PR DESCRIPTION
It seems that `vm.runInContext()` causes the `instanceof` tests to fail. Let's use more reliable `.constructor.name` tests, instead.
