### PR TITLE
Properly clone node's Buffer class

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -51,6 +51,11 @@ function clone(parent, circular) {
           child = new Date(parent.getTime());
         else if (util.isRegExp(parent))
           child = new RegExp(parent.source);
+        else if (Buffer.isBuffer())
+        {
+          child = new Buffer(parent.length);
+          parent.copy(child);
+        }
         else {
           child = {};
 

--- a/test.js
+++ b/test.js
@@ -85,7 +85,16 @@ exports["clone array"] = function(test) {
   test.done();
 };
 
+exports["clone buffer"] = function(test) {
+  test.expect(1);
 
+  var a = new Buffer("this is a test buffer");
+  var b = clone(a);
+    
+  // no underscore equal since it has no concept of Buffers
+  test.deepEqual(b, a);
+  test.done();
+};
 
 exports["clone object containing array"] = function(test) {
   test.expect(2); // how many tests?


### PR DESCRIPTION
Right now, the naive javascript copy clones the buffer pretty well, including it's prototypes.  This gives the impression that the buffer has been properly cloned, and in most cases it may work.  In my repo you'll find a branch with a file (example.tar.gz at: https://github.com/w1nk/node-clone/raw/testcase/example.tar.gz).  If you modify server.js, you'll see where the options cloning is happening.  If you pass the original options object into createServer you'll be prompted with your passphrase (password) and everything will funciton.  If you pass the cloned object in, it'll never prompt you and silently fail.  I've narrowed the issue down I believe into node_crypto.cc, in the LoadBIO function:

``` C++
// Takes a string or buffer and loads it into a BIO.                                                                                                                            
// Caller responsible for BIO_free-ing the returned object.                                                                                                                     
static BIO* LoadBIO (Handle<Value> v) {
  BIO *bio = BIO_new(BIO_s_mem());
  if (!bio) return NULL;

  HandleScope scope;

  int r = -1;

  if (v->IsString()) {
    String::Utf8Value s(v);
    r = BIO_write(bio, *s, s.length());
  } else if (Buffer::HasInstance(v)) {
    Local<Object> buffer_obj = v->ToObject();
    char *buffer_data = Buffer::Data(buffer_obj);
    size_t buffer_length = Buffer::Length(buffer_obj);
    r = BIO_write(bio, buffer_data, buffer_length);
  }

  if (r <= 0) {
    BIO_free(bio);
    return NULL;
  }

  return bio;
}
```

Since the cloned object isn't actually an internal node Buffer, I believe the function is silently failing to load the key properly.
