### PR TITLE
Check if `Buffer` is available before using.

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -19,6 +19,7 @@ module.exports = clone;
 function clone(parent, circular) {
   if (typeof circular == 'undefined')
     circular = true;
+  var useBuffer = 'undefined' !== typeof Buffer;
   var i;
   if (circular) {
     var circularParent = {};
@@ -51,7 +52,7 @@ function clone(parent, circular) {
           child = new Date(parent.getTime());
         else if (util.isRegExp(parent))
           child = new RegExp(parent.source);
-        else if (Buffer.isBuffer(parent))
+        else if (useBuffer && Buffer.isBuffer(parent))
         {
           child = new Buffer(parent.length);
           parent.copy(child);


### PR DESCRIPTION
Allows for use in client-side environments such as browserify/component. I'm sure they'll support `Buffer` eventually, but this keeps it from throwing an error for now :)
