### PR TITLE
removes dependency on `util`

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -1,6 +1,18 @@
 "use strict";
-
-var util = require('util');
+function objectToString(o) {
+  return Object.prototype.toString.call(o);
+}
+var util = {
+  isArray: function (ar) {
+    return Array.isArray(ar) || (typeof ar === 'object' && objectToString(ar) === '[object Array]');
+  },
+  isDate: function (d) {
+    return typeof d === 'object' && objectToString(d) === '[object Date]';
+  },
+  isRegExp: function (re) {
+    return typeof re === 'object' && objectToString(re) === '[object RegExp]';
+  }
+};
 
 module.exports = clone;
 


### PR DESCRIPTION
since i'm using node-clone with an ender build, the dependency on `util` throws an error in the browser (rightfully so) since the dependency isn't found.

given that `util` is only included for `isDate`, `isArray`, and `isRegExp` — I decided to inline those methods to get it working.
