### PR TITLE
Added depth argument

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -39,10 +39,16 @@ if (typeof module === 'object')
  * @param `parent` - the object to be cloned
  * @param `circular` - set to true if the object to be cloned may contain
  *    circular references. (optional - true by default)
+ * @param `depth` - set to a number if the object is only to be cloned to
+ *    a particular depth. (optional - defaults to Infinity)
 */
-function clone(parent, circular) {
+function clone(parent, circular, depth) {
   if (typeof circular == 'undefined')
     circular = true;
+  if (typeof depth == 'undefined')
+    depth = Infinity;
+  if (depth === 0)
+    return parent;
 
   var useBuffer = typeof Buffer != 'undefined';
 
@@ -122,7 +128,7 @@ function clone(parent, circular) {
       if (parent.constructor.name === 'Array') {
         child = [];
         for(i in parent)
-          child[i] = clone(parent[i], circular);
+          child[i] = clone(parent[i], circular, depth - 1);
       }
       else if (util.isDate(parent))
         child = new Date(parent.getTime() );
@@ -133,7 +139,7 @@ function clone(parent, circular) {
         child = {};
         child.__proto__ = parent.__proto__;
         for(i in parent)
-          child[i] = clone(parent[i], circular);
+          child[i] = clone(parent[i], circular, depth - 1);
       }
     }
     else

--- a/test.js
+++ b/test.js
@@ -215,3 +215,24 @@ exports['cloneObjectWithNoConstructor'] = function(test) {
   test.ok(a.foo, b.foo);
   test.done();
 }
+
+exports['clone object with depth argument'] = function (test) {
+    test.expect(6);
+    var a = {
+        foo: {
+            bar : {
+                baz : 'qux'
+            }
+        }
+    };
+    var b = clone(a, false, 1);
+    test.deepEqual(b, a);
+    test.notEqual(b, a);
+    test.strictEqual(b.foo, a.foo);
+
+    b = clone(a, false, 2);
+    test.deepEqual(b, a);
+    test.notEqual(b.foo, a.foo);
+    test.strictEqual(b.foo.bar, a.foo.bar);
+    test.done();
+}


### PR DESCRIPTION
`clone(anObj, false, 1)` results in a shallow clone. We can make it a step deeper with `clone(anObj, false, 2)`.

Currently only works with `circular == false`, but there won't be many use cases where `circular == true` and `depth < Infinity`. I do hope to fix this in a future commit.
