### PR TITLE
Add Option to Override Parent Prototype

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -87,8 +87,8 @@ function clone(parent, circular, depth, prototype) {
       child = new Buffer(parent.length);
       parent.copy(child);
     } else {
-      if (prototype) child = Object.create(prototype);
-      else child = Object.create(Object.getPrototypeOf(parent));
+      if (typeof prototype == 'undefined') child = Object.create(Object.getPrototypeOf(parent));
+      else child = Object.create(prototype);
     }
 
     if (circular) {

--- a/test.js
+++ b/test.js
@@ -246,6 +246,15 @@ exports['maintain prototype chain in clones'] = function (test) {
   test.done();
 }
 
+exports['parent prototype is overriden with prototype provided'] = function (test) {
+  test.expect(1);
+  function Constructor() {}
+  var a = new Constructor();
+  var b = clone(a, true, Infinity, null);
+  test.strictEqual(b.__defineSetter__, undefined);
+  test.done();
+}
+
 exports['clone object with null children'] = function(test) {
   test.expect(1);
   var a = {


### PR DESCRIPTION
For a sandboxing application I'm working on, it is useful to be able to be able to override the parents prototype, removing methods like `__defineGetter__`, `__defineSetter__`.
