### PR TITLE
Change: Add license declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "Benjamin E. Coe <ben@npmjs.com> (https://twitter.com/benjamincoe)",
     "Nathan Zadoks (https://github.com/nathan7)"
   ],
+  "license": "MIT",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
I noticed that you already had a LICENSE file, which is **awsome**!

But, there is also the sorta-community-standard of putting the license in the package.json file. This is super useful for tools like https://github.com/pivotal/LicenseFinder that can automatically find the license of all the projects a company is using.
