### PR TITLE
Improve support for Internet Explorer

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -1,6 +1,10 @@
 var clone = (function() {
 'use strict';
 
+function _instanceof(obj, type) {
+  return type != null && obj instanceof type;
+}
+
 var nativeMap;
 try {
   nativeMap = Map;
@@ -80,11 +84,11 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
       return parent;
     }
 
-    if (parent instanceof nativeMap) {
+    if (_instanceof(parent, nativeMap)) {
       child = new nativeMap();
-    } else if (parent instanceof nativeSet) {
+    } else if (_instanceof(parent, nativeSet)) {
       child = new nativeSet();
-    } else if (parent instanceof nativePromise) {
+    } else if (_instanceof(parent, nativePromise)) {
       child = new nativePromise(function (resolve, reject) {
         parent.then(function(value) {
           resolve(_clone(value, depth - 1));
@@ -103,7 +107,7 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
       child = new Buffer(parent.length);
       parent.copy(child);
       return child;
-    } else if (parent instanceof Error) {
+    } else if (_instanceof(parent, Error)) {
       child = Object.create(parent);
     } else {
       if (typeof prototype == 'undefined') {
@@ -126,7 +130,7 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
       allChildren.push(child);
     }
 
-    if (parent instanceof nativeMap) {
+    if (_instanceof(parent, nativeMap)) {
       var keyIterator = parent.keys();
       while(true) {
         var next = keyIterator.next();
@@ -138,7 +142,7 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
         child.set(keyChild, valueChild);
       }
     }
-    if (parent instanceof nativeSet) {
+    if (_instanceof(parent, nativeSet)) {
       var iterator = parent.keys();
       while(true) {
         var next = iterator.next();

--- a/clone.js
+++ b/clone.js
@@ -131,27 +131,17 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
     }
 
     if (_instanceof(parent, nativeMap)) {
-      var keyIterator = parent.keys();
-      while(true) {
-        var next = keyIterator.next();
-        if (next.done) {
-          break;
-        }
-        var keyChild = _clone(next.value, depth - 1);
-        var valueChild = _clone(parent.get(next.value), depth - 1);
+      parent.forEach(function(value, key) {
+        var keyChild = _clone(key, depth - 1);
+        var valueChild = _clone(value, depth - 1);
         child.set(keyChild, valueChild);
-      }
+      });
     }
     if (_instanceof(parent, nativeSet)) {
-      var iterator = parent.keys();
-      while(true) {
-        var next = iterator.next();
-        if (next.done) {
-          break;
-        }
-        var entryChild = _clone(next.value, depth - 1);
+      parent.forEach(function(value) {
+        var entryChild = _clone(value, depth - 1);
         child.add(entryChild);
-      }
+      });
     }
 
     for (var i in parent) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "fscherwi (https://fscherwi.github.io)",
     "rictic (https://github.com/rictic)",
     "Martin Jurča (https://github.com/jurca)",
-    "Misery Lee <miserylee@foxmail.com> (https://github.com/miserylee)"
+    "Misery Lee <miserylee@foxmail.com> (https://github.com/miserylee)",
+    "Clemens Wolff (https://github.com/c-w)"
   ],
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This pull request fixes two bugs with cloning Maps and Sets on IE:

- IE requires the type argument to `instanceof` to be defined.
- IE does not implement `Map.keys()` and `Set.keys()`.

These bugs currently cause the "clone a native Map" and "clone a native Set" tests in `test.html` to fail on Internet Explorer:

![image](https://cloud.githubusercontent.com/assets/1086421/23725783/c2b9f400-0406-11e7-9f28-f8f775936c08.png)

After applying the changes in this pull request, all the test-cases in `test.html` pass on Internet Explorer, Chrome and Firefox.