### PR TITLE
Errors when cloning instanceof File

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ So, `b.myself` points to `b`, not `a`. Neat!
 
 ## Changelog
 
+### v2.2.0
+
+#### 2017-09-21
+
+  - Skip cloning `instanceof File`
+
 ### v2.1.1
 
 #### 2017-03-09

--- a/clone.js
+++ b/clone.js
@@ -75,6 +75,9 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
     if (parent === null)
       return null;
 
+    if (parent instanceof File)
+      return parent;
+
     if (depth === 0)
       return parent;
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "function",
     "date"
   ],
-  "version": "2.1.1",
+  "version": "2.2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/pvorb/node-clone.git"


### PR DESCRIPTION
I'm receiving an error with version 2.1.1. I use an `<input type="file">` then store the file in an object. Then I attempt to clone the object and receive the following error:

```
Uncaught TypeError: Cannot assign to read only property 'size' of object '#<File>'
    at _clone (clone.js:156)
    at _clone (clone.js:156)
    at clone (clone.js:196)
    at fileDrop (actions.js:13)
    at Dropzone.<anonymous> (bindActionCreators.js:3)
    at Dropzone.onDrop (index.js:324)
    at Object.executeOnChange (LinkedValueUtils.js:132)
    at ReactDOMComponent._handleChange (ReactDOMInput.js:241)
    at Object.ReactErrorUtils.invokeGuardedCallback (ReactErrorUtils.js:69)
    at executeDispatch (EventPluginUtils.js:85)
```

I created a pull request to skip the `File`.