### PR TITLE
fix: copy writable prototype props

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -150,7 +150,9 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
         attrs = Object.getOwnPropertyDescriptor(proto, i);
       }
 
-      if (attrs && attrs.set == null) {
+      // If attribute is not writable and doesn't have a setter, skip it
+      // Re: https://github.com/pvorb/clone/pull/36
+      if (attrs && attrs.set == null && !attrs.writable) {
         continue;
       }
       child[i] = _clone(parent[i], depth - 1);

--- a/test.js
+++ b/test.js
@@ -333,6 +333,24 @@ exports['clone instance with getter'] = function (test) {
   test.done();
 };
 
+exports['clone writable prototype prop'] = function (test) {
+  test.expect(1);
+  function Ctor() {
+    this.prop = 'value';
+  }
+  Object.defineProperty(Ctor.prototype, 'prop', {
+    configurable: true,
+    enumerable: true,
+    writable: true
+  });
+
+  var a = new Ctor();
+  var b = clone(a);
+
+  test.strictEqual(b.prop, 'value');
+  test.done();
+};
+
 if (Object.getOwnPropertySymbols) {
   exports['clone object with symbol properties'] = function (test) {
     var symbol = Symbol();


### PR DESCRIPTION
Hi,

Looks like #36 introduced a bug where prototype properties that don't have a setter won't get copied, even if they are [writable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty). Example:

```javascript
function X() {
  this.test = 'A';
}

Object.defineProperty(X.prototype, 'test', {
  configurable: false,
  writable: true,
  enumerable: true
});

// "X { test: 'A' }"
console.log(new X());
// "X {}", `test` prop omitted!
console.log(clone(new X()));
```

This issue came up in Automattic/mongoose#5896

Thanks for the great lib and happy holidays!