### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -104,7 +104,13 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
     } else if (clone.__isDate(parent)) {
       child = new Date(parent.getTime());
     } else if (useBuffer && Buffer.isBuffer(parent)) {
-      child = new Buffer(parent.length);
+      if (Buffer.allocUnsafe) {
+        // Node.js >= 4.5.0
+        child = Buffer.allocUnsafe(parent.length);
+      } else {
+        // Older Node.js versions
+        child = new Buffer(parent.length);
+      }
       parent.copy(child);
       return child;
     } else if (_instanceof(parent, Error)) {


### PR DESCRIPTION
_This should also give performance improvements on Node.js 8+._

____

Use Buffer.allocUnsafe directly on Node.js >= 4.5.0
This usecase doesn't need zero-filling, as is properly filled with the parent buffer.

This behaves exactly the same as Buffer(number) on 4.x and 6.x, and slightly faster that Buffer(number) on 8.x and above, as doesn't perform zero-fill.

Older Node.js versions (<4.5.0) use the old code path.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor