### PR TITLE
Fix cannot set property only getter

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -153,7 +153,21 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
       if (attrs && attrs.set == null) {
         continue;
       }
-      child[i] = _clone(parent[i], depth - 1);
+      try{
+        let objProperty = Object.getOwnPropertyDescriptor(child, i)
+        if (objProperty.set === 'undefined'){
+          //no setter define. Skip cloning this property
+          continue;
+        }
+        child[i] = _clone(parent[i], depth - 1);
+      } catch(e){
+        if(e instanceof TypeError){
+          // when in strict mode, TypeError will be thrown if child[i] property only has a getter
+          // we can't do anything about this, other than inform the user that this property cannot be set.
+          continue
+        }
+      }
+
     }
 
     if (Object.getOwnPropertySymbols) {

--- a/clone.js
+++ b/clone.js
@@ -155,7 +155,7 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
       }
 
       try{
-        let objProperty = Object.getOwnPropertyDescriptor(parent, i)
+        var objProperty = Object.getOwnPropertyDescriptor(parent, i)
         if (objProperty.set === 'undefined'){
           //no setter defined. Skip cloning this property
           console.log('no setter')

--- a/clone.js
+++ b/clone.js
@@ -153,10 +153,12 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
       if (attrs && attrs.set == null) {
         continue;
       }
+
       try{
-        let objProperty = Object.getOwnPropertyDescriptor(child, i)
+        let objProperty = Object.getOwnPropertyDescriptor(parent, i)
         if (objProperty.set === 'undefined'){
-          //no setter define. Skip cloning this property
+          //no setter defined. Skip cloning this property
+          console.log('no setter')
           continue;
         }
         child[i] = _clone(parent[i], depth - 1);
@@ -164,6 +166,9 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
         if(e instanceof TypeError){
           // when in strict mode, TypeError will be thrown if child[i] property only has a getter
           // we can't do anything about this, other than inform the user that this property cannot be set.
+          continue
+        } else if(e instanceof ReferenceError){
+          //this may happen in non strict mode
           continue
         }
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "rictic (https://github.com/rictic)",
     "Martin Jurča (https://github.com/jurca)",
     "Misery Lee <miserylee@foxmail.com> (https://github.com/miserylee)",
-    "Clemens Wolff (https://github.com/c-w)"
+    "Clemens Wolff (https://github.com/c-w)",
+    "Sabin Thomas (https://github.com/sabinthomas)"
   ],
   "license": "MIT",
   "engines": {

--- a/test.js
+++ b/test.js
@@ -697,7 +697,7 @@ exports["clone should not fail when cloning an object that does not have setters
   });
 
   test.doesNotThrow(
-    ()=>{
+    function(){
       var cloned = clone(source);
     }
   )

--- a/test.js
+++ b/test.js
@@ -684,3 +684,23 @@ exports["clone should mark the cloned non-enumerable properties as non-enumerabl
 
   test.done();
 };
+
+exports["clone should not fail when cloning an object that does not have setters defined on some of its properties"] = function (test) {
+  test.expect(1);
+
+  //init an object with only a getter defined
+  var source = { x: null };
+  Object.defineProperty(source, 'x', { 
+    get: function() { 
+      return x; 
+    }
+  });
+
+  test.doesNotThrow(
+    ()=>{
+      var cloned = clone(source);
+    }
+  )
+
+  test.done();
+};


### PR DESCRIPTION
Fix for #79, #82
Prevent clone throwing a `TypeError` when in strict mode or a `ReferenceError` when attempting to clone objects that do not have `setter` properties defined.

Added a unit test to check for throws in these situations as well. 

Reference
- [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Getter_only) on setter properties