### PR TITLE
Add use of prototype._clone() if found to clone an object. + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ So, `b.myself` points to `b`, not `a`. Neat!
 
 ## Changelog
 
+#### 2018-03-22
+
+  - Add detection of a custom _clone function on an object.  
+If present, use this function to clone the object and all children.  
+This allows for the cloning of objects in any way you wish, 
+and is especially useful if the object is not clonable in the normal way.
+the _clone() fn can be on the object prototype, or directly on the object as a method, 
+and should return the desired cloned object.  See tests for examples.
+
+
 ### v2.1.1
 
 #### 2017-03-09

--- a/README.md
+++ b/README.md
@@ -107,7 +107,12 @@ and is especially useful if the object is not clonable in the normal way.
 the _clone() fn can be on the object prototype, or directly on the object as a method, 
 and should return the desired cloned object.  See tests for examples.
 
+### v2.1.2
 
+#### 2018-03-21
+
+  - Use `Buffer.allocUnsafe()` on Node >= 4.5.0 (contributed by @ChALkeR)
+  
 ### v2.1.1
 
 #### 2017-03-09

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ and should return the desired cloned object.  See tests for examples.
 #### 2018-03-21
 
   - Use `Buffer.allocUnsafe()` on Node >= 4.5.0 (contributed by @ChALkeR)
-  
+
 ### v2.1.1
 
 #### 2017-03-09

--- a/clone.js
+++ b/clone.js
@@ -114,7 +114,8 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
     } else {
       if (typeof prototype == 'undefined') {
         proto = Object.getPrototypeOf(parent);
-        if (proto && proto._clone){
+        // if a _clone function in prototype OR direct on object
+        if (parent._clone){
           child = parent._clone();
           dochildren = false;
         } else {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "rictic (https://github.com/rictic)",
     "Martin Jurča (https://github.com/jurca)",
     "Misery Lee <miserylee@foxmail.com> (https://github.com/miserylee)",
-    "Clemens Wolff (https://github.com/c-w)"
+    "Clemens Wolff (https://github.com/c-w)",
+    "Simon Hailes (https://github.com/btsimonh)"
+    
   ],
   "license": "MIT",
   "engines": {

--- a/test.js
+++ b/test.js
@@ -684,3 +684,33 @@ exports["clone should mark the cloned non-enumerable properties as non-enumerabl
 
   test.done();
 };
+
+
+exports["clone object using _clone"] = function (test) {
+  test.expect(3);
+
+  
+  // create an object with _clone prototype
+  function myobj( name, id ){
+    this.name = name;
+    this.id = id;
+  };
+  
+  // note clone function does not copy complete object.
+  myobj.prototype._clone = function(){
+    var newobj = new myobj( this.name, 'isclone');
+    return newobj;
+  }
+
+  var source = new myobj('myname', 'original');
+  
+
+  var cloned = clone(source);
+  
+  test.equal(cloned.name, source.name);
+  test.equal(cloned.id, 'isclone');
+  test.equal(source.id, 'original');
+
+  test.done();
+};
+

--- a/test.js
+++ b/test.js
@@ -687,7 +687,7 @@ exports["clone should mark the cloned non-enumerable properties as non-enumerabl
 
 
 exports["clone object using _clone"] = function (test) {
-  test.expect(3);
+  test.expect(5);
 
   
   // create an object with _clone prototype
@@ -702,14 +702,35 @@ exports["clone object using _clone"] = function (test) {
     return newobj;
   }
 
+
   var source = new myobj('myname', 'original');
   
+  // also test a (different) direct on object _clone() method
+  source._clone = function(){
+    var newobj = new myobj( this.name, 'isclone2');
+    return newobj;
+  }
 
+  // this will use the *function* we just added to the source object
   var cloned = clone(source);
+  // this will use the prototype we added to the *object defn*
+  var cloned2 = clone(cloned);
+
+  // ensure that out cloned object still has the prototype _clone()
+  var fail = false;
+  if (!cloned._clone){
+      fail = true;
+  }
+  
+  var util = require('util');
+  console.log(util.inspect(cloned));
+  console.log(util.inspect(cloned2));
   
   test.equal(cloned.name, source.name);
-  test.equal(cloned.id, 'isclone');
+  test.equal(cloned.id, 'isclone2');
+  test.equal(cloned2.id, 'isclone');
   test.equal(source.id, 'original');
+  test.equal(fail, false);
 
   test.done();
 };


### PR DESCRIPTION
This commit adds a feature by which if an object has a prototype method _clone(), this method is used to clone that object and all descendants.
Rational:
Currently cloning of an object is done with Object.create().
This does not work for certain objects (specifically node-opencv mat and opencv4nodejs cv.Mat objects).
For any object which does not clone correctly, a user can add a _clone() function and node-clone will then clone to the user's required specification.
Other examples where this is useful:
The _clone() function can do anything the user wants with an object.  For example, it could mearly return the original object, or return the original object with a reference count incremented.  Or as in the test, the clone could be marked as a clone...

questions:  is _clone() as the function name sufficiently 'conflict free'?

- update: modified to allow an object to have a plain function _clone() attached - in this way behaviour for an individual object can be modified as well.  Obviously, if a prototype._clone() method is *not* added, the resulting object may no longer be cloneable.