### PR TITLE
Simplify descriptor handling

### DIFF
--- a/clone.js
+++ b/clone.js
@@ -104,14 +104,14 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
     } else if (clone.__isDate(parent)) {
       child = new Date(parent.getTime());
     } else if (useBuffer && Buffer.isBuffer(parent)) {
-      if (Buffer.allocUnsafe) {
-        // Node.js >= 4.5.0
-        child = Buffer.allocUnsafe(parent.length);
+      if (Buffer.from) {
+        // Node.js >= 5.10.0
+        child = Buffer.from(parent);
       } else {
         // Older Node.js versions
         child = new Buffer(parent.length);
+        parent.copy(child);
       }
-      parent.copy(child);
       return child;
     } else if (_instanceof(parent, Error)) {
       child = Object.create(parent);

--- a/clone.js
+++ b/clone.js
@@ -151,15 +151,10 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
     }
 
     for (var i in parent) {
-      var attrs;
-      if (proto) {
-        attrs = Object.getOwnPropertyDescriptor(proto, i);
+      var attrs = Object.getOwnPropertyDescriptor(parent, i);
+      if (attrs) {
+        child[i] = _clone(parent[i], depth - 1);
       }
-
-      if (attrs && attrs.set == null) {
-        continue;
-      }
-      child[i] = _clone(parent[i], depth - 1);
     }
 
     if (Object.getOwnPropertySymbols) {
@@ -173,11 +168,7 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
           continue;
         }
         child[symbol] = _clone(parent[symbol], depth - 1);
-        if (!descriptor.enumerable) {
-          Object.defineProperty(child, symbol, {
-            enumerable: false
-          });
-        }
+        Object.defineProperty(child, symbol, descriptor);
       }
     }
 
@@ -190,9 +181,7 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
           continue;
         }
         child[propertyName] = _clone(parent[propertyName], depth - 1);
-        Object.defineProperty(child, propertyName, {
-          enumerable: false
-        });
+        Object.defineProperty(child, propertyName, descriptor);
       }
     }
 


### PR DESCRIPTION
I think that the main logic could be simplified a bit.

Running on my own (relatively exhaustive) test suite, this works the same as the previous behaviour.