### PR TITLE
Use URL when available natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ So, `b.myself` points to `b`, not `a`. Neat!
 
 ## Changelog
 
+### v2.1.3
+
+#### 2019-12-16
+
+  - Use native `URL` on Node >= 10.0.0 (contributed by @iambalaam)
+
 ### v2.1.2
 
 #### 2018-03-21

--- a/clone.js
+++ b/clone.js
@@ -21,6 +21,13 @@ try {
   nativeSet = function() {};
 }
 
+var nativeURL;
+try {
+  nativeURL = URL;
+} catch (_) {
+  nativeURL = function () { };
+}
+
 var nativePromise;
 try {
   nativePromise = Promise;
@@ -88,6 +95,8 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
       child = new nativeMap();
     } else if (_instanceof(parent, nativeSet)) {
       child = new nativeSet();
+    } else if (_instanceof(parent, nativeURL)) {
+      child = new nativeURL(parent);
     } else if (_instanceof(parent, nativePromise)) {
       child = new nativePromise(function (resolve, reject) {
         parent.then(function(value) {
@@ -187,7 +196,7 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
           continue;
         }
         child[symbol] = _clone(parent[symbol], depth - 1);
-        Object.defineProperty(child, symbol, descriptor);
+        Object.defineProperty(child, symbol, _clone(descriptor));
       }
     }
 
@@ -200,7 +209,7 @@ function clone(parent, circular, depth, prototype, includeNonEnumerable) {
           continue;
         }
         child[propertyName] = _clone(parent[propertyName], depth - 1);
-        Object.defineProperty(child, propertyName, descriptor);
+        Object.defineProperty(child, propertyName, _clone(descriptor));
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "function",
     "date"
   ],
-  "version": "2.1.2",
+  "version": "2.1.3",
   "repository": {
     "type": "git",
     "url": "git://github.com/pvorb/node-clone.git"
@@ -40,7 +40,8 @@
     "Martin Jurča (https://github.com/jurca)",
     "Misery Lee <miserylee@foxmail.com> (https://github.com/miserylee)",
     "Clemens Wolff (https://github.com/c-w)",
-    "Sabin Thomas (https://github.com/sabinthomas)"
+    "Sabin Thomas (https://github.com/sabinthomas)",
+    "Guy Balaam (https://github.com/iambalaam)"
   ],
   "license": "MIT",
   "engines": {

--- a/test.js
+++ b/test.js
@@ -469,6 +469,47 @@ if (nativeSet) {
   }
 }
 
+var nativeURLSearchParams;
+try {
+  nativeURLSearchParams = URLSearchParams;
+} catch (_) { }
+if (nativeURLSearchParams) {
+  exports["clone a native URLSearchParams"] = function (test) {
+    var searchParams = new URLSearchParams('?query=value');
+    // regular circular expando property
+    searchParams.circle = searchParams;
+
+    var clonedSearchParams = clone(searchParams);
+    test.notEqual(searchParams, clonedSearchParams);
+    test.equal(clonedSearchParams, clonedSearchParams.circle);
+
+    test.done()
+  }
+}
+
+var nativeURL;
+try {
+  nativeURL = URL;
+} catch (_) { }
+if (nativeURL) {
+  exports["clone a native URL"] = function (test) {
+    var url = new URL('https://example.com/path?query=value');
+    // regular circular expando property
+    url.circle = url;
+
+    var clonedUrl = clone(url);
+    test.notEqual(url, clonedUrl);
+    test.equal(clonedUrl.protocol, 'https:');
+    test.equal(clonedUrl.host, 'example.com');
+    test.equal(clonedUrl.pathname, '/path');
+    test.equal(clonedUrl.search, '?query=value');
+    test.equal(clonedUrl.circle, clonedUrl);
+    test.notEqual(url.searchParams, clonedUrl.searchParams);
+
+    test.done();
+  }
+}
+
 var nativePromise;
 try {
   nativePromise = Promise;


### PR DESCRIPTION
- [x] Add a meaningful entry to the changelog in the README.md.
- [x] You can add yourself to the list of contributors in the package.json if you
  like. If you don't do it, you won't be mentioned.

This is my first attempt to solve **Cannot clone a URL in Node >= 10** https://github.com/pvorb/clone/issues/109 .

---
I have had to clone the property descriptors of Symbols, and I assume I should do the same for property names.  
  
When running the following code I found that the `value` wasn't a primitive.  This made the `URL` object clone to a new object, but the `URLSearchParams` inside it point to the same instance.  (I have not assessed the performance implications of this.)
``` js
> const url = new URL('https://example.com/?a=1');
> const querySymbol = Object.getOwnPropertySymbols(url)[1] // Symbol(query)
> Object.getOwnPropertyDescriptor(url, querySymbol)

{ value: URLSearchParams { 'a' => '1' },
  writable: true,
  enumerable: true,
  configurable: true }
```