### PR TITLE
Update repository metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "version": "2.1.2",
   "repository": {
     "type": "git",
-    "url": "git://github.com/pvorb/node-clone.git"
+    "url": "git+https://github.com/pvorb/clone.git"
   },
   "bugs": {
-    "url": "https://github.com/pvorb/node-clone/issues"
+    "url": "https://github.com/pvorb/clone/issues"
   },
   "main": "clone.js",
   "author": "Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch/)",


### PR DESCRIPTION
Summary:
- update the repository metadata from the legacy `git://` URL and old `pvorb/node-clone` path to the current HTTPS repository URL
- update the bugs URL to the current repository issue tracker

Validation:
- fetched `package.json` from the default branch and parsed it as JSON
- asserted `repository.url` is `git+https://github.com/pvorb/clone.git`
- asserted `bugs.url` is `https://github.com/pvorb/clone/issues`